### PR TITLE
Fix -Wpedantic warnings.

### DIFF
--- a/octomap/include/octomap/AbstractOccupancyOcTree.h
+++ b/octomap/include/octomap/AbstractOccupancyOcTree.h
@@ -235,7 +235,7 @@ namespace octomap {
     static const std::string binaryFileHeader;
   };
 
-}; // end namespace
+} // end namespace
 
 
 #endif

--- a/octomap/include/octomap/OcTreeKey.h
+++ b/octomap/include/octomap/OcTreeKey.h
@@ -49,7 +49,7 @@
   #include <tr1/unordered_map>
   namespace octomap {
     namespace unordered_ns = std::tr1;
-  };
+  }
 #else
   #include <unordered_set>
   #include <unordered_map>


### PR DESCRIPTION
This PR intends to fix the `-Wpedantic` warnings shown up when compiling moveit2 against the release version of octomap: `ros-dashing-octomap`. These warnings block the CI of moveit2. Please see [here](https://travis-ci.org/ros-planning/moveit2/jobs/628989417#L988).